### PR TITLE
Actualización de gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,84 @@
-# 🐍 Archivos compilados por Python
-src/SatisPlanning/__pycache__/
+# Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
-*.so
+*$py.class
 .vscode/
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py

--- a/requerimiento.txt
+++ b/requerimiento.txt
@@ -1,0 +1,2 @@
+pygame
+perlin_noise


### PR DESCRIPTION
Viendo la clase de Juanma, pasa una plantilla de gitignore para un proyecto en python, la busque y actualice para que quede completa, la compare con la que ya estaba. Solo queda ver si no ignora algún archivo que no debería. Por otro lado agregue el archivo "requerimeintos.txt" en el cual se escriben solo el nombre de las librerías utilizadas que requieran instalación con el comando "pip", "pip3" o similares, para que sea mas simple en otras maquinas ya que utilizando el comando "pip install requerimientos.txt" se instala todo lo que esta ahí (el comando cambia según el OS) 